### PR TITLE
Feat: adapt Morpho interfaces with granular pausing

### DIFF
--- a/abis/aave-v2/mainnet/MorphoAaveV2.json
+++ b/abis/aave-v2/mainnet/MorphoAaveV2.json
@@ -574,6 +574,139 @@
       },
       {
         "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsBorrowPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isDeprecated",
+        "type": "bool"
+      }
+    ],
+    "name": "IsDeprecatedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsLiquidateBorrowPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsLiquidateCollateralPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsRepayPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsSupplyPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsWithdrawPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
         "internalType": "uint16",
         "name": "_reserveFactor",
         "type": "uint16"
@@ -1400,6 +1533,55 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "marketPauseStatus",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isSupplyPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBorrowPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isWithdrawPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isRepayPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isLiquidateCollateralPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isLiquidateBorrowPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isDeprecated",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "maxSortedUsers",
     "outputs": [
@@ -1675,6 +1857,176 @@
       }
     ],
     "name": "setInterestRatesManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsBorrowPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsClaimRewardsPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isDeprecated",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsDeprecated",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsLiquidateBorrowPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsLiquidateCollateralPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isP2PDisabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsP2PDisabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsPausedForAllMarkets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsRepayPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsSupplyPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsWithdrawPaused",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/abis/compound/MorphoCompound.json
+++ b/abis/compound/MorphoCompound.json
@@ -125,7 +125,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -168,7 +168,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -205,7 +205,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -273,7 +273,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -298,7 +298,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -317,7 +317,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -348,7 +348,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -391,7 +391,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -428,7 +428,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -465,7 +465,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -570,7 +570,140 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsBorrowPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isDeprecated",
+        "type": "bool"
+      }
+    ],
+    "name": "IsDeprecatedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsLiquidateBorrowPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsLiquidateCollateralPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsRepayPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsSupplyPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "IsWithdrawPausedSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -627,7 +760,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -646,13 +779,13 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "bool",
-        "name": "_p2pDisabled",
+        "name": "_isP2PDisabled",
         "type": "bool"
       }
     ],
@@ -665,7 +798,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -684,7 +817,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -716,7 +849,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -735,7 +868,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -868,7 +1001,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -886,7 +1019,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -969,7 +1102,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1000,7 +1133,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1161,7 +1294,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1185,7 +1318,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1438,6 +1571,55 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "marketPauseStatus",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isSupplyPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isBorrowPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isWithdrawPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isRepayPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isLiquidateCollateralPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isLiquidateBorrowPaused",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isDeprecated",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
@@ -1561,7 +1743,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1670,6 +1852,176 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsBorrowPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsClaimRewardsPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isDeprecated",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsDeprecated",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsLiquidateBorrowPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsLiquidateCollateralPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isP2PDisabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsP2PDisabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsPausedForAllMarkets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsRepayPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsSupplyPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_poolToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsWithdrawPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_newMaxSortedUsers",
         "type": "uint256"
@@ -1684,7 +2036,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1702,7 +2054,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1720,7 +2072,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1738,7 +2090,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1769,7 +2121,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1813,7 +2165,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1836,7 +2188,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {
@@ -1919,7 +2271,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       }
     ],
@@ -1969,7 +2321,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_poolTokenAddress",
+        "name": "_poolToken",
         "type": "address"
       },
       {

--- a/src/aave-v2/mainnet/MorphoAaveV2.ts
+++ b/src/aave-v2/mainnet/MorphoAaveV2.ts
@@ -82,6 +82,7 @@ export interface MorphoAaveV2Interface extends utils.Interface {
     "isClaimRewardsPaused()": FunctionFragment;
     "liquidate(address,address,address,uint256)": FunctionFragment;
     "market(address)": FunctionFragment;
+    "marketPauseStatus(address)": FunctionFragment;
     "maxSortedUsers()": FunctionFragment;
     "owner()": FunctionFragment;
     "p2pBorrowIndex(address)": FunctionFragment;
@@ -99,6 +100,16 @@ export interface MorphoAaveV2Interface extends utils.Interface {
     "setExitPositionsManager(address)": FunctionFragment;
     "setIncentivesVault(address)": FunctionFragment;
     "setInterestRatesManager(address)": FunctionFragment;
+    "setIsBorrowPaused(address,bool)": FunctionFragment;
+    "setIsClaimRewardsPaused(bool)": FunctionFragment;
+    "setIsDeprecated(address,bool)": FunctionFragment;
+    "setIsLiquidateBorrowPaused(address,bool)": FunctionFragment;
+    "setIsLiquidateCollateralPaused(address,bool)": FunctionFragment;
+    "setIsP2PDisabled(address,bool)": FunctionFragment;
+    "setIsPausedForAllMarkets(bool)": FunctionFragment;
+    "setIsRepayPaused(address,bool)": FunctionFragment;
+    "setIsSupplyPaused(address,bool)": FunctionFragment;
+    "setIsWithdrawPaused(address,bool)": FunctionFragment;
     "setMaxSortedUsers(uint256)": FunctionFragment;
     "setP2PDisabledStatus(address,bool)": FunctionFragment;
     "setP2PIndexCursor(address,uint16)": FunctionFragment;
@@ -150,6 +161,7 @@ export interface MorphoAaveV2Interface extends utils.Interface {
       | "isClaimRewardsPaused"
       | "liquidate"
       | "market"
+      | "marketPauseStatus"
       | "maxSortedUsers"
       | "owner"
       | "p2pBorrowIndex"
@@ -167,6 +179,16 @@ export interface MorphoAaveV2Interface extends utils.Interface {
       | "setExitPositionsManager"
       | "setIncentivesVault"
       | "setInterestRatesManager"
+      | "setIsBorrowPaused"
+      | "setIsClaimRewardsPaused"
+      | "setIsDeprecated"
+      | "setIsLiquidateBorrowPaused"
+      | "setIsLiquidateCollateralPaused"
+      | "setIsP2PDisabled"
+      | "setIsPausedForAllMarkets"
+      | "setIsRepayPaused"
+      | "setIsSupplyPaused"
+      | "setIsWithdrawPaused"
       | "setMaxSortedUsers"
       | "setP2PDisabledStatus"
       | "setP2PIndexCursor"
@@ -328,6 +350,10 @@ export interface MorphoAaveV2Interface extends utils.Interface {
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
+    functionFragment: "marketPauseStatus",
+    values: [PromiseOrValue<string>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "maxSortedUsers",
     values?: undefined
   ): string;
@@ -392,6 +418,46 @@ export interface MorphoAaveV2Interface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "setInterestRatesManager",
     values: [PromiseOrValue<string>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsBorrowPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsClaimRewardsPaused",
+    values: [PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsDeprecated",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsLiquidateBorrowPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsLiquidateCollateralPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsP2PDisabled",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsPausedForAllMarkets",
+    values: [PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsRepayPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsSupplyPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsWithdrawPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
   ): string;
   encodeFunctionData(
     functionFragment: "setMaxSortedUsers",
@@ -568,6 +634,10 @@ export interface MorphoAaveV2Interface extends utils.Interface {
   decodeFunctionResult(functionFragment: "liquidate", data: BytesLike): Result;
   decodeFunctionResult(functionFragment: "market", data: BytesLike): Result;
   decodeFunctionResult(
+    functionFragment: "marketPauseStatus",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "maxSortedUsers",
     data: BytesLike
   ): Result;
@@ -624,6 +694,46 @@ export interface MorphoAaveV2Interface extends utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "setInterestRatesManager",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsBorrowPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsClaimRewardsPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsDeprecated",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsLiquidateBorrowPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsLiquidateCollateralPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsP2PDisabled",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsPausedForAllMarkets",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsRepayPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsSupplyPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsWithdrawPaused",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -711,6 +821,13 @@ export interface MorphoAaveV2Interface extends utils.Interface {
     "ExitPositionsManagerSet(address)": EventFragment;
     "IncentivesVaultSet(address)": EventFragment;
     "InterestRatesSet(address)": EventFragment;
+    "IsBorrowPausedSet(address,bool)": EventFragment;
+    "IsDeprecatedSet(address,bool)": EventFragment;
+    "IsLiquidateBorrowPausedSet(address,bool)": EventFragment;
+    "IsLiquidateCollateralPausedSet(address,bool)": EventFragment;
+    "IsRepayPausedSet(address,bool)": EventFragment;
+    "IsSupplyPausedSet(address,bool)": EventFragment;
+    "IsWithdrawPausedSet(address,bool)": EventFragment;
     "MarketCreated(address,uint16,uint16)": EventFragment;
     "MaxSortedUsersSet(uint256)": EventFragment;
     "OwnershipTransferred(address,address)": EventFragment;
@@ -747,6 +864,15 @@ export interface MorphoAaveV2Interface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "ExitPositionsManagerSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "IncentivesVaultSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "InterestRatesSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsBorrowPausedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsDeprecatedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsLiquidateBorrowPausedSet"): EventFragment;
+  getEvent(
+    nameOrSignatureOrTopic: "IsLiquidateCollateralPausedSet"
+  ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsRepayPausedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsSupplyPausedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsWithdrawPausedSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MarketCreated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MaxSortedUsersSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnershipTransferred"): EventFragment;
@@ -991,6 +1117,89 @@ export type InterestRatesSetEvent = TypedEvent<
 
 export type InterestRatesSetEventFilter =
   TypedEventFilter<InterestRatesSetEvent>;
+
+export interface IsBorrowPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsBorrowPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsBorrowPausedSetEventObject
+>;
+
+export type IsBorrowPausedSetEventFilter =
+  TypedEventFilter<IsBorrowPausedSetEvent>;
+
+export interface IsDeprecatedSetEventObject {
+  _poolToken: string;
+  _isDeprecated: boolean;
+}
+export type IsDeprecatedSetEvent = TypedEvent<
+  [string, boolean],
+  IsDeprecatedSetEventObject
+>;
+
+export type IsDeprecatedSetEventFilter = TypedEventFilter<IsDeprecatedSetEvent>;
+
+export interface IsLiquidateBorrowPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsLiquidateBorrowPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsLiquidateBorrowPausedSetEventObject
+>;
+
+export type IsLiquidateBorrowPausedSetEventFilter =
+  TypedEventFilter<IsLiquidateBorrowPausedSetEvent>;
+
+export interface IsLiquidateCollateralPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsLiquidateCollateralPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsLiquidateCollateralPausedSetEventObject
+>;
+
+export type IsLiquidateCollateralPausedSetEventFilter =
+  TypedEventFilter<IsLiquidateCollateralPausedSetEvent>;
+
+export interface IsRepayPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsRepayPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsRepayPausedSetEventObject
+>;
+
+export type IsRepayPausedSetEventFilter =
+  TypedEventFilter<IsRepayPausedSetEvent>;
+
+export interface IsSupplyPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsSupplyPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsSupplyPausedSetEventObject
+>;
+
+export type IsSupplyPausedSetEventFilter =
+  TypedEventFilter<IsSupplyPausedSetEvent>;
+
+export interface IsWithdrawPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsWithdrawPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsWithdrawPausedSetEventObject
+>;
+
+export type IsWithdrawPausedSetEventFilter =
+  TypedEventFilter<IsWithdrawPausedSetEvent>;
 
 export interface MarketCreatedEventObject {
   _poolToken: string;
@@ -1308,6 +1517,21 @@ export interface MorphoAaveV2 extends BaseContract {
       }
     >;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<
+      [boolean, boolean, boolean, boolean, boolean, boolean, boolean] & {
+        isSupplyPaused: boolean;
+        isBorrowPaused: boolean;
+        isWithdrawPaused: boolean;
+        isRepayPaused: boolean;
+        isLiquidateCollateralPaused: boolean;
+        isLiquidateBorrowPaused: boolean;
+        isDeprecated: boolean;
+      }
+    >;
+
     maxSortedUsers(overrides?: CallOverrides): Promise<[BigNumber]>;
 
     owner(overrides?: CallOverrides): Promise<[string]>;
@@ -1386,6 +1610,64 @@ export interface MorphoAaveV2 extends BaseContract {
 
     setInterestRatesManager(
       _interestRatesManager: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -1634,6 +1916,21 @@ export interface MorphoAaveV2 extends BaseContract {
     }
   >;
 
+  marketPauseStatus(
+    arg0: PromiseOrValue<string>,
+    overrides?: CallOverrides
+  ): Promise<
+    [boolean, boolean, boolean, boolean, boolean, boolean, boolean] & {
+      isSupplyPaused: boolean;
+      isBorrowPaused: boolean;
+      isWithdrawPaused: boolean;
+      isRepayPaused: boolean;
+      isLiquidateCollateralPaused: boolean;
+      isLiquidateBorrowPaused: boolean;
+      isDeprecated: boolean;
+    }
+  >;
+
   maxSortedUsers(overrides?: CallOverrides): Promise<BigNumber>;
 
   owner(overrides?: CallOverrides): Promise<string>;
@@ -1712,6 +2009,64 @@ export interface MorphoAaveV2 extends BaseContract {
 
   setInterestRatesManager(
     _interestRatesManager: PromiseOrValue<string>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsBorrowPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsClaimRewardsPaused(
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsDeprecated(
+    _poolToken: PromiseOrValue<string>,
+    _isDeprecated: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsLiquidateBorrowPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsLiquidateCollateralPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsP2PDisabled(
+    _poolToken: PromiseOrValue<string>,
+    _isP2PDisabled: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsPausedForAllMarkets(
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsRepayPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsSupplyPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsWithdrawPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -1960,6 +2315,21 @@ export interface MorphoAaveV2 extends BaseContract {
       }
     >;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<
+      [boolean, boolean, boolean, boolean, boolean, boolean, boolean] & {
+        isSupplyPaused: boolean;
+        isBorrowPaused: boolean;
+        isWithdrawPaused: boolean;
+        isRepayPaused: boolean;
+        isLiquidateCollateralPaused: boolean;
+        isLiquidateBorrowPaused: boolean;
+        isDeprecated: boolean;
+      }
+    >;
+
     maxSortedUsers(overrides?: CallOverrides): Promise<BigNumber>;
 
     owner(overrides?: CallOverrides): Promise<string>;
@@ -2036,6 +2406,64 @@ export interface MorphoAaveV2 extends BaseContract {
 
     setInterestRatesManager(
       _interestRatesManager: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -2339,6 +2767,69 @@ export interface MorphoAaveV2 extends BaseContract {
       _interestRatesManager?: PromiseOrValue<string> | null
     ): InterestRatesSetEventFilter;
 
+    "IsBorrowPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsBorrowPausedSetEventFilter;
+    IsBorrowPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsBorrowPausedSetEventFilter;
+
+    "IsDeprecatedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isDeprecated?: null
+    ): IsDeprecatedSetEventFilter;
+    IsDeprecatedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isDeprecated?: null
+    ): IsDeprecatedSetEventFilter;
+
+    "IsLiquidateBorrowPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateBorrowPausedSetEventFilter;
+    IsLiquidateBorrowPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateBorrowPausedSetEventFilter;
+
+    "IsLiquidateCollateralPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateCollateralPausedSetEventFilter;
+    IsLiquidateCollateralPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateCollateralPausedSetEventFilter;
+
+    "IsRepayPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsRepayPausedSetEventFilter;
+    IsRepayPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsRepayPausedSetEventFilter;
+
+    "IsSupplyPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsSupplyPausedSetEventFilter;
+    IsSupplyPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsSupplyPausedSetEventFilter;
+
+    "IsWithdrawPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsWithdrawPausedSetEventFilter;
+    IsWithdrawPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsWithdrawPausedSetEventFilter;
+
     "MarketCreated(address,uint16,uint16)"(
       _poolToken?: PromiseOrValue<string> | null,
       _reserveFactor?: null,
@@ -2567,6 +3058,11 @@ export interface MorphoAaveV2 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     maxSortedUsers(overrides?: CallOverrides): Promise<BigNumber>;
 
     owner(overrides?: CallOverrides): Promise<BigNumber>;
@@ -2639,6 +3135,64 @@ export interface MorphoAaveV2 extends BaseContract {
 
     setInterestRatesManager(
       _interestRatesManager: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -2874,6 +3428,11 @@ export interface MorphoAaveV2 extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
     maxSortedUsers(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     owner(overrides?: CallOverrides): Promise<PopulatedTransaction>;
@@ -2946,6 +3505,64 @@ export interface MorphoAaveV2 extends BaseContract {
 
     setInterestRatesManager(
       _interestRatesManager: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/src/compound/MorphoCompound.ts
+++ b/src/compound/MorphoCompound.ts
@@ -90,6 +90,7 @@ export interface MorphoCompoundInterface extends utils.Interface {
     "liquidate(address,address,address,uint256)": FunctionFragment;
     "marketParameters(address)": FunctionFragment;
     "marketStatus(address)": FunctionFragment;
+    "marketPauseStatus(address)": FunctionFragment;
     "marketsCreated(uint256)": FunctionFragment;
     "maxSortedUsers()": FunctionFragment;
     "owner()": FunctionFragment;
@@ -104,6 +105,16 @@ export interface MorphoCompoundInterface extends utils.Interface {
     "setDustThreshold(uint256)": FunctionFragment;
     "setIncentivesVault(address)": FunctionFragment;
     "setInterestRates(address)": FunctionFragment;
+    "setIsBorrowPaused(address,bool)": FunctionFragment;
+    "setIsClaimRewardsPaused(bool)": FunctionFragment;
+    "setIsDeprecated(address,bool)": FunctionFragment;
+    "setIsLiquidateBorrowPaused(address,bool)": FunctionFragment;
+    "setIsLiquidateCollateralPaused(address,bool)": FunctionFragment;
+    "setIsP2PDisabled(address,bool)": FunctionFragment;
+    "setIsPausedForAllMarkets(bool)": FunctionFragment;
+    "setIsRepayPaused(address,bool)": FunctionFragment;
+    "setIsSupplyPaused(address,bool)": FunctionFragment;
+    "setIsWithdrawPaused(address,bool)": FunctionFragment;
     "setMaxSortedUsers(uint256)": FunctionFragment;
     "setP2PDisable(address,bool)": FunctionFragment;
     "setP2PIndexCursor(address,uint16)": FunctionFragment;
@@ -154,6 +165,7 @@ export interface MorphoCompoundInterface extends utils.Interface {
       | "liquidate"
       | "marketParameters"
       | "marketStatus"
+      | "marketPauseStatus"
       | "marketsCreated"
       | "maxSortedUsers"
       | "owner"
@@ -168,6 +180,16 @@ export interface MorphoCompoundInterface extends utils.Interface {
       | "setDustThreshold"
       | "setIncentivesVault"
       | "setInterestRates"
+      | "setIsBorrowPaused"
+      | "setIsClaimRewardsPaused"
+      | "setIsDeprecated"
+      | "setIsLiquidateBorrowPaused"
+      | "setIsLiquidateCollateralPaused"
+      | "setIsP2PDisabled"
+      | "setIsPausedForAllMarkets"
+      | "setIsRepayPaused"
+      | "setIsSupplyPaused"
+      | "setIsWithdrawPaused"
       | "setMaxSortedUsers"
       | "setP2PDisable"
       | "setP2PIndexCursor"
@@ -317,6 +339,10 @@ export interface MorphoCompoundInterface extends utils.Interface {
     values: [PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
+    functionFragment: "marketPauseStatus",
+    values: [PromiseOrValue<string>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "marketsCreated",
     values: [PromiseOrValue<BigNumberish>]
   ): string;
@@ -372,6 +398,46 @@ export interface MorphoCompoundInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "setInterestRates",
     values: [PromiseOrValue<string>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsBorrowPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsClaimRewardsPaused",
+    values: [PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsDeprecated",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsLiquidateBorrowPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsLiquidateCollateralPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsP2PDisabled",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsPausedForAllMarkets",
+    values: [PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsRepayPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsSupplyPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setIsWithdrawPaused",
+    values: [PromiseOrValue<string>, PromiseOrValue<boolean>]
   ): string;
   encodeFunctionData(
     functionFragment: "setMaxSortedUsers",
@@ -544,6 +610,10 @@ export interface MorphoCompoundInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "marketPauseStatus",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "marketsCreated",
     data: BytesLike
   ): Result;
@@ -591,6 +661,46 @@ export interface MorphoCompoundInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "setInterestRates",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsBorrowPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsClaimRewardsPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsDeprecated",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsLiquidateBorrowPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsLiquidateCollateralPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsP2PDisabled",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsPausedForAllMarkets",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsRepayPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsSupplyPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setIsWithdrawPaused",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -676,6 +786,13 @@ export interface MorphoCompoundInterface extends utils.Interface {
     "DustThresholdSet(uint256)": EventFragment;
     "IncentivesVaultSet(address)": EventFragment;
     "InterestRatesSet(address)": EventFragment;
+    "IsBorrowPausedSet(address,bool)": EventFragment;
+    "IsDeprecatedSet(address,bool)": EventFragment;
+    "IsLiquidateBorrowPausedSet(address,bool)": EventFragment;
+    "IsLiquidateCollateralPausedSet(address,bool)": EventFragment;
+    "IsRepayPausedSet(address,bool)": EventFragment;
+    "IsSupplyPausedSet(address,bool)": EventFragment;
+    "IsWithdrawPausedSet(address,bool)": EventFragment;
     "MarketCreated(address,uint16,uint16)": EventFragment;
     "MaxSortedUsersSet(uint256)": EventFragment;
     "OwnershipTransferred(address,address)": EventFragment;
@@ -709,6 +826,15 @@ export interface MorphoCompoundInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "DustThresholdSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "IncentivesVaultSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "InterestRatesSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsBorrowPausedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsDeprecatedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsLiquidateBorrowPausedSet"): EventFragment;
+  getEvent(
+    nameOrSignatureOrTopic: "IsLiquidateCollateralPausedSet"
+  ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsRepayPausedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsSupplyPausedSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "IsWithdrawPausedSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MarketCreated"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MaxSortedUsersSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnershipTransferred"): EventFragment;
@@ -726,7 +852,7 @@ export interface MorphoCompoundInterface extends utils.Interface {
 }
 
 export interface P2PIndexesUpdatedEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _p2pSupplyIndex: BigNumber;
   _p2pBorrowIndex: BigNumber;
   _poolSupplyIndex: BigNumber;
@@ -742,7 +868,7 @@ export type P2PIndexesUpdatedEventFilter =
 
 export interface BorrowedEventObject {
   _borrower: string;
-  _poolTokenAddress: string;
+  _poolToken: string;
   _amount: BigNumber;
   _balanceOnPool: BigNumber;
   _balanceInP2P: BigNumber;
@@ -756,7 +882,7 @@ export type BorrowedEventFilter = TypedEventFilter<BorrowedEvent>;
 
 export interface BorrowerPositionUpdatedEventObject {
   _user: string;
-  _poolTokenAddress: string;
+  _poolToken: string;
   _balanceOnPool: BigNumber;
   _balanceInP2P: BigNumber;
 }
@@ -784,7 +910,7 @@ export type LiquidatedEvent = TypedEvent<
 export type LiquidatedEventFilter = TypedEventFilter<LiquidatedEvent>;
 
 export interface P2PAmountsUpdatedEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _p2pSupplyAmount: BigNumber;
   _p2pBorrowAmount: BigNumber;
 }
@@ -797,7 +923,7 @@ export type P2PAmountsUpdatedEventFilter =
   TypedEventFilter<P2PAmountsUpdatedEvent>;
 
 export interface P2PBorrowDeltaUpdatedEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _p2pBorrowDelta: BigNumber;
 }
 export type P2PBorrowDeltaUpdatedEvent = TypedEvent<
@@ -809,7 +935,7 @@ export type P2PBorrowDeltaUpdatedEventFilter =
   TypedEventFilter<P2PBorrowDeltaUpdatedEvent>;
 
 export interface P2PSupplyDeltaUpdatedEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _p2pSupplyDelta: BigNumber;
 }
 export type P2PSupplyDeltaUpdatedEvent = TypedEvent<
@@ -823,7 +949,7 @@ export type P2PSupplyDeltaUpdatedEventFilter =
 export interface RepaidEventObject {
   _repayer: string;
   _onBehalf: string;
-  _poolTokenAddress: string;
+  _poolToken: string;
   _amount: BigNumber;
   _balanceOnPool: BigNumber;
   _balanceInP2P: BigNumber;
@@ -838,7 +964,7 @@ export type RepaidEventFilter = TypedEventFilter<RepaidEvent>;
 export interface SuppliedEventObject {
   _supplier: string;
   _onBehalf: string;
-  _poolTokenAddress: string;
+  _poolToken: string;
   _amount: BigNumber;
   _balanceOnPool: BigNumber;
   _balanceInP2P: BigNumber;
@@ -852,7 +978,7 @@ export type SuppliedEventFilter = TypedEventFilter<SuppliedEvent>;
 
 export interface SupplierPositionUpdatedEventObject {
   _user: string;
-  _poolTokenAddress: string;
+  _poolToken: string;
   _balanceOnPool: BigNumber;
   _balanceInP2P: BigNumber;
 }
@@ -867,7 +993,7 @@ export type SupplierPositionUpdatedEventFilter =
 export interface WithdrawnEventObject {
   _supplier: string;
   _receiver: string;
-  _poolTokenAddress: string;
+  _poolToken: string;
   _amount: BigNumber;
   _balanceOnPool: BigNumber;
   _balanceInP2P: BigNumber;
@@ -923,8 +1049,91 @@ export type InterestRatesSetEvent = TypedEvent<
 export type InterestRatesSetEventFilter =
   TypedEventFilter<InterestRatesSetEvent>;
 
+export interface IsBorrowPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsBorrowPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsBorrowPausedSetEventObject
+>;
+
+export type IsBorrowPausedSetEventFilter =
+  TypedEventFilter<IsBorrowPausedSetEvent>;
+
+export interface IsDeprecatedSetEventObject {
+  _poolToken: string;
+  _isDeprecated: boolean;
+}
+export type IsDeprecatedSetEvent = TypedEvent<
+  [string, boolean],
+  IsDeprecatedSetEventObject
+>;
+
+export type IsDeprecatedSetEventFilter = TypedEventFilter<IsDeprecatedSetEvent>;
+
+export interface IsLiquidateBorrowPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsLiquidateBorrowPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsLiquidateBorrowPausedSetEventObject
+>;
+
+export type IsLiquidateBorrowPausedSetEventFilter =
+  TypedEventFilter<IsLiquidateBorrowPausedSetEvent>;
+
+export interface IsLiquidateCollateralPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsLiquidateCollateralPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsLiquidateCollateralPausedSetEventObject
+>;
+
+export type IsLiquidateCollateralPausedSetEventFilter =
+  TypedEventFilter<IsLiquidateCollateralPausedSetEvent>;
+
+export interface IsRepayPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsRepayPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsRepayPausedSetEventObject
+>;
+
+export type IsRepayPausedSetEventFilter =
+  TypedEventFilter<IsRepayPausedSetEvent>;
+
+export interface IsSupplyPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsSupplyPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsSupplyPausedSetEventObject
+>;
+
+export type IsSupplyPausedSetEventFilter =
+  TypedEventFilter<IsSupplyPausedSetEvent>;
+
+export interface IsWithdrawPausedSetEventObject {
+  _poolToken: string;
+  _isPaused: boolean;
+}
+export type IsWithdrawPausedSetEvent = TypedEvent<
+  [string, boolean],
+  IsWithdrawPausedSetEventObject
+>;
+
+export type IsWithdrawPausedSetEventFilter =
+  TypedEventFilter<IsWithdrawPausedSetEvent>;
+
 export interface MarketCreatedEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _reserveFactor: number;
   _p2pIndexCursor: number;
 }
@@ -959,7 +1168,7 @@ export type OwnershipTransferredEventFilter =
   TypedEventFilter<OwnershipTransferredEvent>;
 
 export interface P2PIndexCursorSetEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _newValue: number;
 }
 export type P2PIndexCursorSetEvent = TypedEvent<
@@ -971,8 +1180,8 @@ export type P2PIndexCursorSetEventFilter =
   TypedEventFilter<P2PIndexCursorSetEvent>;
 
 export interface P2PStatusSetEventObject {
-  _poolTokenAddress: string;
-  _p2pDisabled: boolean;
+  _poolToken: string;
+  _isP2PDisabled: boolean;
 }
 export type P2PStatusSetEvent = TypedEvent<
   [string, boolean],
@@ -982,7 +1191,7 @@ export type P2PStatusSetEvent = TypedEvent<
 export type P2PStatusSetEventFilter = TypedEventFilter<P2PStatusSetEvent>;
 
 export interface PartialPauseStatusSetEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _newStatus: boolean;
 }
 export type PartialPauseStatusSetEvent = TypedEvent<
@@ -994,7 +1203,7 @@ export type PartialPauseStatusSetEventFilter =
   TypedEventFilter<PartialPauseStatusSetEvent>;
 
 export interface PauseStatusSetEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _newStatus: boolean;
 }
 export type PauseStatusSetEvent = TypedEvent<
@@ -1016,7 +1225,7 @@ export type PositionsManagerSetEventFilter =
   TypedEventFilter<PositionsManagerSetEvent>;
 
 export interface ReserveFactorSetEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _newValue: number;
 }
 export type ReserveFactorSetEvent = TypedEvent<
@@ -1028,7 +1237,7 @@ export type ReserveFactorSetEventFilter =
   TypedEventFilter<ReserveFactorSetEvent>;
 
 export interface ReserveFeeClaimedEventObject {
-  _poolTokenAddress: string;
+  _poolToken: string;
   _amountClaimed: BigNumber;
 }
 export type ReserveFeeClaimedEvent = TypedEvent<
@@ -1120,13 +1329,13 @@ export interface MorphoCompound extends BaseContract {
     WAD(overrides?: CallOverrides): Promise<[BigNumber]>;
 
     "borrow(address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     "borrow(address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -1149,7 +1358,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<ContractTransaction>;
 
     claimToTreasury(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -1157,7 +1366,7 @@ export interface MorphoCompound extends BaseContract {
     comptroller(overrides?: CallOverrides): Promise<[string]>;
 
     createMarket(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _marketParams: Types.MarketParametersStruct,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -1203,13 +1412,13 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<[string[]] & { enteredMarkets_: string[] }>;
 
     getHead(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<[string] & { head: string }>;
 
     getNext(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       _user: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1273,6 +1482,21 @@ export interface MorphoCompound extends BaseContract {
       }
     >;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<
+      [boolean, boolean, boolean, boolean, boolean, boolean, boolean] & {
+        isSupplyPaused: boolean;
+        isBorrowPaused: boolean;
+        isWithdrawPaused: boolean;
+        isRepayPaused: boolean;
+        isLiquidateCollateralPaused: boolean;
+        isLiquidateBorrowPaused: boolean;
+        isDeprecated: boolean;
+      }
+    >;
+
     marketsCreated(
       arg0: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1304,7 +1528,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<ContractTransaction>;
 
     repay(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -1332,31 +1556,89 @@ export interface MorphoCompound extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     setMaxSortedUsers(
       _newMaxSortedUsers: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     setP2PDisable(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     setP2PIndexCursor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _p2pIndexCursor: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     setPartialPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     setPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -1367,7 +1649,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<ContractTransaction>;
 
     setReserveFactor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newReserveFactor: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -1383,14 +1665,14 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<ContractTransaction>;
 
     "supply(address,address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
     "supply(address,address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
@@ -1413,7 +1695,7 @@ export interface MorphoCompound extends BaseContract {
     treasuryVault(overrides?: CallOverrides): Promise<[string]>;
 
     updateP2PIndexes(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -1426,7 +1708,7 @@ export interface MorphoCompound extends BaseContract {
     wEth(overrides?: CallOverrides): Promise<[string]>;
 
     withdraw(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
@@ -1441,13 +1723,13 @@ export interface MorphoCompound extends BaseContract {
   WAD(overrides?: CallOverrides): Promise<BigNumber>;
 
   "borrow(address,uint256)"(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   "borrow(address,uint256,uint256)"(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     _maxGasForMatching: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -1468,7 +1750,7 @@ export interface MorphoCompound extends BaseContract {
   ): Promise<ContractTransaction>;
 
   claimToTreasury(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -1476,7 +1758,7 @@ export interface MorphoCompound extends BaseContract {
   comptroller(overrides?: CallOverrides): Promise<string>;
 
   createMarket(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _marketParams: Types.MarketParametersStruct,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -1520,13 +1802,13 @@ export interface MorphoCompound extends BaseContract {
   ): Promise<string[]>;
 
   getHead(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _positionType: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
   ): Promise<string>;
 
   getNext(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _positionType: PromiseOrValue<BigNumberish>,
     _user: PromiseOrValue<string>,
     overrides?: CallOverrides
@@ -1590,6 +1872,21 @@ export interface MorphoCompound extends BaseContract {
     }
   >;
 
+  marketPauseStatus(
+    arg0: PromiseOrValue<string>,
+    overrides?: CallOverrides
+  ): Promise<
+    [boolean, boolean, boolean, boolean, boolean, boolean, boolean] & {
+      isSupplyPaused: boolean;
+      isBorrowPaused: boolean;
+      isWithdrawPaused: boolean;
+      isRepayPaused: boolean;
+      isLiquidateCollateralPaused: boolean;
+      isLiquidateBorrowPaused: boolean;
+      isDeprecated: boolean;
+    }
+  >;
+
   marketsCreated(
     arg0: PromiseOrValue<BigNumberish>,
     overrides?: CallOverrides
@@ -1621,7 +1918,7 @@ export interface MorphoCompound extends BaseContract {
   ): Promise<ContractTransaction>;
 
   repay(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _onBehalf: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -1649,31 +1946,89 @@ export interface MorphoCompound extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  setIsBorrowPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsClaimRewardsPaused(
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsDeprecated(
+    _poolToken: PromiseOrValue<string>,
+    _isDeprecated: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsLiquidateBorrowPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsLiquidateCollateralPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsP2PDisabled(
+    _poolToken: PromiseOrValue<string>,
+    _isP2PDisabled: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsPausedForAllMarkets(
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsRepayPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsSupplyPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setIsWithdrawPaused(
+    _poolToken: PromiseOrValue<string>,
+    _isPaused: PromiseOrValue<boolean>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   setMaxSortedUsers(
     _newMaxSortedUsers: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   setP2PDisable(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _newStatus: PromiseOrValue<boolean>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   setP2PIndexCursor(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _p2pIndexCursor: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   setPartialPauseStatus(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _newStatus: PromiseOrValue<boolean>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   setPauseStatus(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _newStatus: PromiseOrValue<boolean>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -1684,7 +2039,7 @@ export interface MorphoCompound extends BaseContract {
   ): Promise<ContractTransaction>;
 
   setReserveFactor(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _newReserveFactor: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -1700,14 +2055,14 @@ export interface MorphoCompound extends BaseContract {
   ): Promise<ContractTransaction>;
 
   "supply(address,address,uint256)"(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _onBehalf: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
   "supply(address,address,uint256,uint256)"(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _onBehalf: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     _maxGasForMatching: PromiseOrValue<BigNumberish>,
@@ -1728,7 +2083,7 @@ export interface MorphoCompound extends BaseContract {
   treasuryVault(overrides?: CallOverrides): Promise<string>;
 
   updateP2PIndexes(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -1741,7 +2096,7 @@ export interface MorphoCompound extends BaseContract {
   wEth(overrides?: CallOverrides): Promise<string>;
 
   withdraw(
-    _poolTokenAddress: PromiseOrValue<string>,
+    _poolToken: PromiseOrValue<string>,
     _amount: PromiseOrValue<BigNumberish>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
@@ -1756,13 +2111,13 @@ export interface MorphoCompound extends BaseContract {
     WAD(overrides?: CallOverrides): Promise<BigNumber>;
 
     "borrow(address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     "borrow(address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1785,7 +2140,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<void>;
 
     claimToTreasury(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
@@ -1793,7 +2148,7 @@ export interface MorphoCompound extends BaseContract {
     comptroller(overrides?: CallOverrides): Promise<string>;
 
     createMarket(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _marketParams: Types.MarketParametersStruct,
       overrides?: CallOverrides
     ): Promise<void>;
@@ -1837,13 +2192,13 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<string[]>;
 
     getHead(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<string>;
 
     getNext(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       _user: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1907,6 +2262,21 @@ export interface MorphoCompound extends BaseContract {
       }
     >;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<
+      [boolean, boolean, boolean, boolean, boolean, boolean, boolean] & {
+        isSupplyPaused: boolean;
+        isBorrowPaused: boolean;
+        isWithdrawPaused: boolean;
+        isRepayPaused: boolean;
+        isLiquidateCollateralPaused: boolean;
+        isLiquidateBorrowPaused: boolean;
+        isDeprecated: boolean;
+      }
+    >;
+
     marketsCreated(
       arg0: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1936,7 +2306,7 @@ export interface MorphoCompound extends BaseContract {
     renounceOwnership(overrides?: CallOverrides): Promise<void>;
 
     repay(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -1964,31 +2334,89 @@ export interface MorphoCompound extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
     setMaxSortedUsers(
       _newMaxSortedUsers: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     setP2PDisable(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     setP2PIndexCursor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _p2pIndexCursor: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     setPartialPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     setPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: CallOverrides
     ): Promise<void>;
@@ -1999,7 +2427,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<void>;
 
     setReserveFactor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newReserveFactor: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
@@ -2015,14 +2443,14 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<void>;
 
     "supply(address,address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
 
     "supply(address,address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
@@ -2045,7 +2473,7 @@ export interface MorphoCompound extends BaseContract {
     treasuryVault(overrides?: CallOverrides): Promise<string>;
 
     updateP2PIndexes(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -2058,7 +2486,7 @@ export interface MorphoCompound extends BaseContract {
     wEth(overrides?: CallOverrides): Promise<string>;
 
     withdraw(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<void>;
@@ -2066,14 +2494,14 @@ export interface MorphoCompound extends BaseContract {
 
   filters: {
     "P2PIndexesUpdated(address,uint256,uint256,uint256,uint256)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pSupplyIndex?: null,
       _p2pBorrowIndex?: null,
       _poolSupplyIndex?: null,
       _poolBorrowIndex?: null
     ): P2PIndexesUpdatedEventFilter;
     P2PIndexesUpdated(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pSupplyIndex?: null,
       _p2pBorrowIndex?: null,
       _poolSupplyIndex?: null,
@@ -2082,14 +2510,14 @@ export interface MorphoCompound extends BaseContract {
 
     "Borrowed(address,address,uint256,uint256,uint256)"(
       _borrower?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
     ): BorrowedEventFilter;
     Borrowed(
       _borrower?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2097,13 +2525,13 @@ export interface MorphoCompound extends BaseContract {
 
     "BorrowerPositionUpdated(address,address,uint256,uint256)"(
       _user?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
     ): BorrowerPositionUpdatedEventFilter;
     BorrowerPositionUpdated(
       _user?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
     ): BorrowerPositionUpdatedEventFilter;
@@ -2126,38 +2554,38 @@ export interface MorphoCompound extends BaseContract {
     ): LiquidatedEventFilter;
 
     "P2PAmountsUpdated(address,uint256,uint256)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pSupplyAmount?: null,
       _p2pBorrowAmount?: null
     ): P2PAmountsUpdatedEventFilter;
     P2PAmountsUpdated(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pSupplyAmount?: null,
       _p2pBorrowAmount?: null
     ): P2PAmountsUpdatedEventFilter;
 
     "P2PBorrowDeltaUpdated(address,uint256)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pBorrowDelta?: null
     ): P2PBorrowDeltaUpdatedEventFilter;
     P2PBorrowDeltaUpdated(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pBorrowDelta?: null
     ): P2PBorrowDeltaUpdatedEventFilter;
 
     "P2PSupplyDeltaUpdated(address,uint256)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pSupplyDelta?: null
     ): P2PSupplyDeltaUpdatedEventFilter;
     P2PSupplyDeltaUpdated(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _p2pSupplyDelta?: null
     ): P2PSupplyDeltaUpdatedEventFilter;
 
     "Repaid(address,address,address,uint256,uint256,uint256)"(
       _repayer?: PromiseOrValue<string> | null,
       _onBehalf?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2165,7 +2593,7 @@ export interface MorphoCompound extends BaseContract {
     Repaid(
       _repayer?: PromiseOrValue<string> | null,
       _onBehalf?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2174,7 +2602,7 @@ export interface MorphoCompound extends BaseContract {
     "Supplied(address,address,address,uint256,uint256,uint256)"(
       _supplier?: PromiseOrValue<string> | null,
       _onBehalf?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2182,7 +2610,7 @@ export interface MorphoCompound extends BaseContract {
     Supplied(
       _supplier?: PromiseOrValue<string> | null,
       _onBehalf?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2190,13 +2618,13 @@ export interface MorphoCompound extends BaseContract {
 
     "SupplierPositionUpdated(address,address,uint256,uint256)"(
       _user?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
     ): SupplierPositionUpdatedEventFilter;
     SupplierPositionUpdated(
       _user?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
     ): SupplierPositionUpdatedEventFilter;
@@ -2204,7 +2632,7 @@ export interface MorphoCompound extends BaseContract {
     "Withdrawn(address,address,address,uint256,uint256,uint256)"(
       _supplier?: PromiseOrValue<string> | null,
       _receiver?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2212,7 +2640,7 @@ export interface MorphoCompound extends BaseContract {
     Withdrawn(
       _supplier?: PromiseOrValue<string> | null,
       _receiver?: PromiseOrValue<string> | null,
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amount?: null,
       _balanceOnPool?: null,
       _balanceInP2P?: null
@@ -2244,13 +2672,76 @@ export interface MorphoCompound extends BaseContract {
       _interestRatesManager?: PromiseOrValue<string> | null
     ): InterestRatesSetEventFilter;
 
+    "IsBorrowPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsBorrowPausedSetEventFilter;
+    IsBorrowPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsBorrowPausedSetEventFilter;
+
+    "IsDeprecatedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isDeprecated?: null
+    ): IsDeprecatedSetEventFilter;
+    IsDeprecatedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isDeprecated?: null
+    ): IsDeprecatedSetEventFilter;
+
+    "IsLiquidateBorrowPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateBorrowPausedSetEventFilter;
+    IsLiquidateBorrowPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateBorrowPausedSetEventFilter;
+
+    "IsLiquidateCollateralPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateCollateralPausedSetEventFilter;
+    IsLiquidateCollateralPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsLiquidateCollateralPausedSetEventFilter;
+
+    "IsRepayPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsRepayPausedSetEventFilter;
+    IsRepayPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsRepayPausedSetEventFilter;
+
+    "IsSupplyPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsSupplyPausedSetEventFilter;
+    IsSupplyPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsSupplyPausedSetEventFilter;
+
+    "IsWithdrawPausedSet(address,bool)"(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsWithdrawPausedSetEventFilter;
+    IsWithdrawPausedSet(
+      _poolToken?: PromiseOrValue<string> | null,
+      _isPaused?: null
+    ): IsWithdrawPausedSetEventFilter;
+
     "MarketCreated(address,uint16,uint16)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _reserveFactor?: null,
       _p2pIndexCursor?: null
     ): MarketCreatedEventFilter;
     MarketCreated(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _reserveFactor?: null,
       _p2pIndexCursor?: null
     ): MarketCreatedEventFilter;
@@ -2270,38 +2761,38 @@ export interface MorphoCompound extends BaseContract {
     ): OwnershipTransferredEventFilter;
 
     "P2PIndexCursorSet(address,uint16)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newValue?: null
     ): P2PIndexCursorSetEventFilter;
     P2PIndexCursorSet(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newValue?: null
     ): P2PIndexCursorSetEventFilter;
 
     "P2PStatusSet(address,bool)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
-      _p2pDisabled?: null
+      _poolToken?: PromiseOrValue<string> | null,
+      _isP2PDisabled?: null
     ): P2PStatusSetEventFilter;
     P2PStatusSet(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
-      _p2pDisabled?: null
+      _poolToken?: PromiseOrValue<string> | null,
+      _isP2PDisabled?: null
     ): P2PStatusSetEventFilter;
 
     "PartialPauseStatusSet(address,bool)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newStatus?: null
     ): PartialPauseStatusSetEventFilter;
     PartialPauseStatusSet(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newStatus?: null
     ): PartialPauseStatusSetEventFilter;
 
     "PauseStatusSet(address,bool)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newStatus?: null
     ): PauseStatusSetEventFilter;
     PauseStatusSet(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newStatus?: null
     ): PauseStatusSetEventFilter;
 
@@ -2313,20 +2804,20 @@ export interface MorphoCompound extends BaseContract {
     ): PositionsManagerSetEventFilter;
 
     "ReserveFactorSet(address,uint16)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newValue?: null
     ): ReserveFactorSetEventFilter;
     ReserveFactorSet(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _newValue?: null
     ): ReserveFactorSetEventFilter;
 
     "ReserveFeeClaimed(address,uint256)"(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amountClaimed?: null
     ): ReserveFeeClaimedEventFilter;
     ReserveFeeClaimed(
-      _poolTokenAddress?: PromiseOrValue<string> | null,
+      _poolToken?: PromiseOrValue<string> | null,
       _amountClaimed?: null
     ): ReserveFeeClaimedEventFilter;
 
@@ -2373,13 +2864,13 @@ export interface MorphoCompound extends BaseContract {
     WAD(overrides?: CallOverrides): Promise<BigNumber>;
 
     "borrow(address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     "borrow(address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -2400,7 +2891,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<BigNumber>;
 
     claimToTreasury(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -2408,7 +2899,7 @@ export interface MorphoCompound extends BaseContract {
     comptroller(overrides?: CallOverrides): Promise<BigNumber>;
 
     createMarket(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _marketParams: Types.MarketParametersStruct,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -2436,13 +2927,13 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<BigNumber>;
 
     getHead(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     getNext(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       _user: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -2492,6 +2983,11 @@ export interface MorphoCompound extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     marketsCreated(
       arg0: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -2523,7 +3019,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<BigNumber>;
 
     repay(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -2551,31 +3047,89 @@ export interface MorphoCompound extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     setMaxSortedUsers(
       _newMaxSortedUsers: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     setP2PDisable(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     setP2PIndexCursor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _p2pIndexCursor: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     setPartialPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     setPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -2586,7 +3140,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<BigNumber>;
 
     setReserveFactor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newReserveFactor: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -2602,14 +3156,14 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<BigNumber>;
 
     "supply(address,address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     "supply(address,address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
@@ -2630,7 +3184,7 @@ export interface MorphoCompound extends BaseContract {
     treasuryVault(overrides?: CallOverrides): Promise<BigNumber>;
 
     updateP2PIndexes(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -2643,7 +3197,7 @@ export interface MorphoCompound extends BaseContract {
     wEth(overrides?: CallOverrides): Promise<BigNumber>;
 
     withdraw(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
@@ -2661,13 +3215,13 @@ export interface MorphoCompound extends BaseContract {
     WAD(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     "borrow(address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     "borrow(address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -2688,7 +3242,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     claimToTreasury(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
@@ -2696,7 +3250,7 @@ export interface MorphoCompound extends BaseContract {
     comptroller(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     createMarket(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _marketParams: Types.MarketParametersStruct,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
@@ -2726,13 +3280,13 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     getHead(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     getNext(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _positionType: PromiseOrValue<BigNumberish>,
       _user: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -2784,6 +3338,11 @@ export interface MorphoCompound extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
+    marketPauseStatus(
+      arg0: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
     marketsCreated(
       arg0: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
@@ -2815,7 +3374,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     repay(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -2843,31 +3402,89 @@ export interface MorphoCompound extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    setIsBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsClaimRewardsPaused(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsDeprecated(
+      _poolToken: PromiseOrValue<string>,
+      _isDeprecated: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsLiquidateBorrowPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsLiquidateCollateralPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsP2PDisabled(
+      _poolToken: PromiseOrValue<string>,
+      _isP2PDisabled: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsPausedForAllMarkets(
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsRepayPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsSupplyPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setIsWithdrawPaused(
+      _poolToken: PromiseOrValue<string>,
+      _isPaused: PromiseOrValue<boolean>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     setMaxSortedUsers(
       _newMaxSortedUsers: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     setP2PDisable(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     setP2PIndexCursor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _p2pIndexCursor: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     setPartialPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     setPauseStatus(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newStatus: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
@@ -2878,7 +3495,7 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     setReserveFactor(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _newReserveFactor: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
@@ -2894,14 +3511,14 @@ export interface MorphoCompound extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     "supply(address,address,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     "supply(address,address,uint256,uint256)"(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _onBehalf: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       _maxGasForMatching: PromiseOrValue<BigNumberish>,
@@ -2922,7 +3539,7 @@ export interface MorphoCompound extends BaseContract {
     treasuryVault(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     updateP2PIndexes(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
@@ -2935,7 +3552,7 @@ export interface MorphoCompound extends BaseContract {
     wEth(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     withdraw(
-      _poolTokenAddress: PromiseOrValue<string>,
+      _poolToken: PromiseOrValue<string>,
       _amount: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;

--- a/src/factories/aave-v2/mainnet/MorphoAaveV2__factory.ts
+++ b/src/factories/aave-v2/mainnet/MorphoAaveV2__factory.ts
@@ -586,6 +586,139 @@ const _abi = [
       },
       {
         indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsBorrowPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isDeprecated",
+        type: "bool",
+      },
+    ],
+    name: "IsDeprecatedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsLiquidateBorrowPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsLiquidateCollateralPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsRepayPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsSupplyPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsWithdrawPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
         internalType: "uint16",
         name: "_reserveFactor",
         type: "uint16",
@@ -1412,6 +1545,55 @@ const _abi = [
     type: "function",
   },
   {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "marketPauseStatus",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "isSupplyPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isBorrowPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isWithdrawPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isRepayPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isLiquidateCollateralPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isLiquidateBorrowPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isDeprecated",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [],
     name: "maxSortedUsers",
     outputs: [
@@ -1687,6 +1869,176 @@ const _abi = [
       },
     ],
     name: "setInterestRatesManager",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsBorrowPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsClaimRewardsPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isDeprecated",
+        type: "bool",
+      },
+    ],
+    name: "setIsDeprecated",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsLiquidateBorrowPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsLiquidateCollateralPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isP2PDisabled",
+        type: "bool",
+      },
+    ],
+    name: "setIsP2PDisabled",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsPausedForAllMarkets",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsRepayPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsSupplyPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsWithdrawPaused",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/src/factories/compound/MorphoCompound__factory.ts
+++ b/src/factories/compound/MorphoCompound__factory.ts
@@ -137,7 +137,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -180,7 +180,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -217,7 +217,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -285,7 +285,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -310,7 +310,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -329,7 +329,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -360,7 +360,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -403,7 +403,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -440,7 +440,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -477,7 +477,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -582,7 +582,140 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsBorrowPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isDeprecated",
+        type: "bool",
+      },
+    ],
+    name: "IsDeprecatedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsLiquidateBorrowPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsLiquidateCollateralPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsRepayPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsSupplyPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "IsWithdrawPausedSet",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -639,7 +772,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -658,13 +791,13 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
         indexed: false,
         internalType: "bool",
-        name: "_p2pDisabled",
+        name: "_isP2PDisabled",
         type: "bool",
       },
     ],
@@ -677,7 +810,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -696,7 +829,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -728,7 +861,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -747,7 +880,7 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -880,7 +1013,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -898,7 +1031,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -981,7 +1114,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1012,7 +1145,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1173,7 +1306,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1197,7 +1330,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1450,6 +1583,55 @@ const _abi = [
   {
     inputs: [
       {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "marketPauseStatus",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "isSupplyPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isBorrowPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isWithdrawPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isRepayPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isLiquidateCollateralPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isLiquidateBorrowPaused",
+        type: "bool",
+      },
+      {
+        internalType: "bool",
+        name: "isDeprecated",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint256",
         name: "",
         type: "uint256",
@@ -1573,7 +1755,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1682,6 +1864,176 @@ const _abi = [
   {
     inputs: [
       {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsBorrowPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsClaimRewardsPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isDeprecated",
+        type: "bool",
+      },
+    ],
+    name: "setIsDeprecated",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsLiquidateBorrowPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsLiquidateCollateralPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isP2PDisabled",
+        type: "bool",
+      },
+    ],
+    name: "setIsP2PDisabled",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsPausedForAllMarkets",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsRepayPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsSupplyPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_poolToken",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_isPaused",
+        type: "bool",
+      },
+    ],
+    name: "setIsWithdrawPaused",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint256",
         name: "_newMaxSortedUsers",
         type: "uint256",
@@ -1696,7 +2048,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1714,7 +2066,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1732,7 +2084,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1750,7 +2102,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1781,7 +2133,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1825,7 +2177,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1848,7 +2200,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {
@@ -1931,7 +2283,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
     ],
@@ -1981,7 +2333,7 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_poolTokenAddress",
+        name: "_poolToken",
         type: "address",
       },
       {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

- adapt the ABI with granular pausing
- keep the previous events to keep the ABI working through blocks, especially for `PartialPauseStatusSet` and `PauseStatusSet` even if they are no longer in the interface, they are emitted before the upgrade
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `yarn lint` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
