### PR TITLE
git(hooks): Add warning to prevent commit with wrong syntaxes

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -4,7 +4,7 @@ COMMIT_MSG_FILE="$1"
 
 exec < /dev/tty
 
-if ! grep -iqE "((feat)|(fix)|(build))\([a-zA-Z0-9]+\):.+" "$COMMIT_MSG_FILE"; then
+if ! grep -iqE "((feat)|(fix)|(build))\([a-zA-Z0-9_-]+\)\!?:.+" "$COMMIT_MSG_FILE"; then
 	while true; do
 	read -p "This commit probably won't trigger a release. Do you want to continue? (N/y) " yn
 	if [ "$yn" = "" ]; then

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+COMMIT_MSG_FILE="$1"
+
+exec < /dev/tty
+
+if ! grep -iqE "((feat)|(fix)|(build))\([a-zA-Z0-9]+\):.+" "$COMMIT_MSG_FILE"; then
+	while true; do
+	read -p "This commit probably won't trigger a release. Do you want to continue? (N/y) " yn
+	if [ "$yn" = "" ]; then
+		yn='N'
+	fi
+	case $yn in
+		[Yy] ) break;;
+		[Nn] ) exit 1;;
+		* ) echo "Please answer y or n for yes or no.";;
+	esac
+	done
+fi
+
+exit 0

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -4,7 +4,7 @@ COMMIT_MSG_FILE="$1"
 
 exec < /dev/tty
 
-if ! grep -iqE "((feat)|(fix)|(build))\([a-zA-Z0-9_-]+\)\!?:.+" "$COMMIT_MSG_FILE"; then
+if ! grep -iqE "((feat)|(fix)|(build))(\([a-zA-Z0-9_-]+\))?\!?:.+" "$COMMIT_MSG_FILE"; then
 	while true; do
 	read -p "This commit probably won't trigger a release. Do you want to continue? (N/y) " yn
 	if [ "$yn" = "" ]; then


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

The commits adds a hook to prevent developers from commiting changes in a wrong format which would prevent a new version of the package to be released

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] `yarn lint` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
